### PR TITLE
Enable query caching for multiple ActiveRecord::Base subclasses

### DIFF
--- a/lib/query_cache.rb
+++ b/lib/query_cache.rb
@@ -10,16 +10,18 @@ require "rack/body_proxy"
 # https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/query_cache.rb
 module QueryCache
   class Middleware
-    cattr_accessor :base
+    class << self
+      attr_accessor :base
+    end
 
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      connection = base.connection
+      connection = self.class.base.connection
       enabled = connection.query_cache_enabled
-      connection_id = base.connection_id
+      connection_id = self.class.base.connection_id
       connection.enable_query_cache!
 
       response = @app.call(env)
@@ -35,9 +37,9 @@ module QueryCache
     private
 
     def restore_query_cache_settings(connection_id, enabled)
-      base.connection_id = connection_id
-      base.connection.clear_query_cache
-      base.connection.disable_query_cache! unless enabled
+      self.class.base.connection_id = connection_id
+      self.class.base.connection.clear_query_cache
+      self.class.base.connection.disable_query_cache! unless enabled
     end
   end
 


### PR DESCRIPTION
I have multiple `ActiveRecord::Base` subclasses—each connecting to different databases with different schemas on different hosts in an SOA.

``` ruby
class FooModel < ActiveRecord::Base
  self.abstract_class = true
end

class BarModel < ActiveRecord::Base
  self.abstract_class = true
end
```

When I try to turn on query caching for all of them,

``` ruby
use QueryCache.for(FooModel)
use QueryCache.for(BarModel)
```

the query cache for `BarModel` is the only one that takes effect.

This change enables query caching for all `ActiveRecord::Base` subclasses.

---
- [ ] コミットメッセージを変える
  - `Enable query caching for multiple ActiveRecord::Base subclasses`
- [ ] 綺麗に修正できたら本家にPR出す
